### PR TITLE
Default to standard x64 calling convention if none is supplied

### DIFF
--- a/Source/Reloaded.Hooks.Definitions/X64/FunctionAttribute.cs
+++ b/Source/Reloaded.Hooks.Definitions/X64/FunctionAttribute.cs
@@ -123,9 +123,8 @@ namespace Reloaded.Hooks.Definitions.X64
                 if (attribute is IFunctionAttribute reloadedFunction)
                     return reloadedFunction;
             }
-
-            throw new Exception($"ReloadedFunctionAttribute is missing in the {typeof(TFunction).Name} delegate declaration." +
-                                    $"Please mark the {typeof(TFunction).Name} with an appropriate ReloadedFunctionAttribute");
+            
+            return new FunctionAttribute(CallingConventions.Microsoft);
         }
 
         /* Override Equals & GetHashCode: ReSharper Generated */


### PR DESCRIPTION
This changes the behaviour around hooks where a default calling convention isn't supplied, though I'm not 100% sure if this is a best-fit fix, but didn't want to also write a bunch of extra code to pass a default through a `Hook` constructor if it's not necessary.

I figure that this is a reasonable default for x64 given it's not the hellscape that x86 is so a default option won't cause any unexpected breakages (or unlikely to), but still allows for the previous behaviour. x86 has been left as is given the aformentioned hellscape that is x86 calling conventions.

If you'd prefer this to be done via a constructor overload (or something else) I can move things around.