### PR TITLE
Fixed AsmHook buffer size prediction.

### DIFF
--- a/Source/Reloaded.Hooks/AsmHook.cs
+++ b/Source/Reloaded.Hooks/AsmHook.cs
@@ -96,11 +96,14 @@ namespace Reloaded.Hooks
             int numberOfStubs          = 3; // Also number of allocations.
             int alignmentRequiredBytes = (codeAlignment * numberOfStubs);
 
+            int pointerSize            = (_is64Bit ? 8 : 4);
+
+            int pointerRequiredBytes   = pointerSize * 2; // 2 calls to AssembleAbsoluteJump
             int stubEntrySize          = MaxJmpSize;
             int stubHookSize           = asmCode.Length + hookLength + MaxJmpSize;
-            int stubOriginalSize       = hookLength + MaxJmpSize;
+            int stubOriginalSize       = hookLength + MaxJmpSize + pointerSize; // 1 call to AssembleAbsoluteJump
 
-            int requiredSizeOfBuffer   = stubEntrySize + stubHookSize + stubOriginalSize + alignmentRequiredBytes;
+            int requiredSizeOfBuffer   = stubEntrySize + stubHookSize + stubOriginalSize + alignmentRequiredBytes + pointerRequiredBytes;
             var buffer                 = Utilities.FindOrCreateBufferInRange(requiredSizeOfBuffer);
 
             buffer.ExecuteWithLock(() =>


### PR DESCRIPTION
Fixes https://github.com/Reloaded-Project/Reloaded.Hooks/issues/4

Three calls to `Utilities.AssembleAbsoluteJump` were uncounted for when requesting a buffer.
https://github.com/Reloaded-Project/Reloaded.Hooks/blob/26cf3c361de015e178815bd93534892a42b16938/Source/Reloaded.Hooks/AsmHook.cs#L118
https://github.com/Reloaded-Project/Reloaded.Hooks/blob/26cf3c361de015e178815bd93534892a42b16938/Source/Reloaded.Hooks/AsmHook.cs#L119
https://github.com/Reloaded-Project/Reloaded.Hooks/blob/26cf3c361de015e178815bd93534892a42b16938/Source/Reloaded.Hooks/AsmHook.cs#L168