### PR TITLE
Add HookedObjectVirtualFunctionTable

### DIFF
--- a/source/Reloaded.Hooks.Tests.X64/HookedObjectVtableTest.cs
+++ b/source/Reloaded.Hooks.Tests.X64/HookedObjectVtableTest.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using Reloaded.Hooks.Definitions;
+using Reloaded.Hooks.Tests.Shared;
+using Reloaded.Hooks.Tools;
+using Xunit;
+
+namespace Reloaded.Hooks.Tests.X64
+{
+    public class HookedObjectVtableTest : IDisposable
+    {
+        private NativeCalculator _nativeCalculator;
+
+        private IHook<NativeCalculator.AddFunction> _addHook;
+        private IHook<NativeCalculator.SubtractFunction> _subHook;
+        private IHook<NativeCalculator.DivideFunction> _divideHook;
+        private IHook<NativeCalculator.MultiplyFunction> _multiplyHook;
+
+        public HookedObjectVtableTest()
+        {
+            _nativeCalculator = new NativeCalculator();
+        }
+
+        public void Dispose()
+        {
+            _nativeCalculator?.Dispose();
+        }
+
+        [Fact]
+        public void TestFunctionPtr()
+        {
+            // Note: All delegates are the same; this test will need to be changed if they ever change.
+            FunctionPtr<NativeCalculator.AddFunction> functionPtr = new FunctionPtr<NativeCalculator.AddFunction>((ulong) _nativeCalculator.VTable);
+
+            for (int x = 1; x < 100; x++)
+            {
+                for (int y = 100; y > 0; y--)
+                {
+                    int add = x + y;
+                    int subtract = x - y;
+                    int multiply = x * y;
+                    int divide = x / y;
+
+                    Assert.Equal(add, functionPtr[(int) NativeCalculator.VTableFunctions.Add](x, y));
+                    Assert.Equal(subtract, functionPtr[(int) NativeCalculator.VTableFunctions.Subtract](x, y));
+                    Assert.Equal(multiply, functionPtr[(int) NativeCalculator.VTableFunctions.Multiply](x, y));
+                    Assert.Equal(divide, functionPtr[(int) NativeCalculator.VTableFunctions.Divide](x, y));
+                }
+            }
+        }
+
+        [Fact]
+        public unsafe void TestInternalVTableCallAfterVTablePointerIsHooked()
+        {
+            // HookedObjectVirtualFunctionTable only supports hooking objects
+            // where the vtable pointer is at [objectbaseadress]
+            // to test this, we create a pointer to our vtable.
+            // this serves as a fake object, which we can hook
+            IntPtr vTableOriginal = _nativeCalculator.VTable;
+            IntPtr fakeObject = new IntPtr(&vTableOriginal);
+            // we hook the vtable pointer(fakeObject), this changes the vtable pointer but does not hook any functions yet
+            var vTableHook = HookedObjectVirtualFunctionTable.HookObject(fakeObject, Enum.GetNames(typeof(NativeCalculator.VTableFunctions)).Length); ;
+            
+            // Setup calling functions.
+            var addFunction = vTableHook.CreateWrapperFunction<NativeCalculator.AddFunction>((int) NativeCalculator.VTableFunctions.Add);
+            var subtractFunction = vTableHook.CreateWrapperFunction<NativeCalculator.SubtractFunction>((int) NativeCalculator.VTableFunctions.Subtract);
+            var multiplyFunction = vTableHook.CreateWrapperFunction<NativeCalculator.MultiplyFunction>((int) NativeCalculator.VTableFunctions.Multiply);
+            var divideFunction = vTableHook.CreateWrapperFunction<NativeCalculator.DivideFunction>((int) NativeCalculator.VTableFunctions.Divide);
+            // This test only tests if calling functions using HookedObjectVirtualFunctionTable still works
+            // We need another test to check if -others- can still call the vtable functions without prolems
+            // This is done in TestExternalVTableCallAfterVTablePointerIsHooked and TestExternalVTableCallAfterFunctionHook
+            // Test Calling after we hook the vtable pointer using our HookedObjectVirtualFunctionTable
+            // This should not modify any results
+            for (int x = 1; x < 100; x++)
+            {
+                for (int y = 100; y > 0; y--)
+                {
+                    int add = x + y;
+                    int subtract = x - y;
+                    int multiply = x * y;
+                    int divide = x / y;
+
+                    Assert.Equal(add, addFunction(x, y));
+                    Assert.Equal(subtract, subtractFunction(x, y));
+                    Assert.Equal(multiply, multiplyFunction(x, y));
+                    Assert.Equal(divide, divideFunction(x, y));
+                }
+            }
+        }
+        [Fact]
+        public unsafe void TestExternalVTableCallAfterVTablePointerIsHooked()
+        {
+            // HookedObjectVirtualFunctionTable only supports hooking objects
+            // where the vtable pointer is at [objectbaseadress]
+            // to test this, we create a pointer to our vtable.
+            // this serves as a fake object, which we can hook
+            IntPtr vTableOriginal = _nativeCalculator.VTable;
+            IntPtr fakeObject = new IntPtr(&vTableOriginal);
+            // We hook the vtable pointer(fakeObject), this changes the vtable pointer but does not hook any functions yet
+            // Checking if this corrupts anything is done in TestVTableHookExternalCallBeforeHook
+            var vTableHook = HookedObjectVirtualFunctionTable.HookObject(fakeObject, Enum.GetNames(typeof(NativeCalculator.VTableFunctions)).Length); ;
+
+            // We create a VirtualFunctionTable from our fakeObject
+            // Calling the functions should call our hooks
+
+            var vTable = VirtualFunctionTable.FromObject(fakeObject, Enum.GetNames(typeof(NativeCalculator.VTableFunctions)).Length);
+            var addFunction = vTable.CreateWrapperFunction<NativeCalculator.AddFunction>((int)NativeCalculator.VTableFunctions.Add);
+            var subtractFunction = vTable.CreateWrapperFunction<NativeCalculator.SubtractFunction>((int)NativeCalculator.VTableFunctions.Subtract);
+            var multiplyFunction = vTable.CreateWrapperFunction<NativeCalculator.MultiplyFunction>((int)NativeCalculator.VTableFunctions.Multiply);
+            var divideFunction = vTable.CreateWrapperFunction<NativeCalculator.DivideFunction>((int)NativeCalculator.VTableFunctions.Divide);
+            // Test Calling after we hook the vtable pointer using an 'external' class (VirtualFunctionTable)
+            // This should not modify any results
+            for (int x = 1; x < 100; x++)
+            {
+                for (int y = 100; y > 0; y--)
+                {
+                    int add = x + y;
+                    int subtract = x - y;
+                    int multiply = x * y;
+                    int divide = x / y;
+
+                    Assert.Equal(add, addFunction(x, y));
+                    Assert.Equal(subtract, subtractFunction(x, y));
+                    Assert.Equal(multiply, multiplyFunction(x, y));
+                    Assert.Equal(divide, divideFunction(x, y));
+                }
+            }
+        }
+        [Fact]
+        public unsafe void TestExternalVTableCallAfterFunctionHook()
+        {
+            int addHook(int a, int b) { return _addHook.OriginalFunction(a, b) + 1; }
+            int subHook(int a, int b) { return _subHook.OriginalFunction(a, b) - 1; }
+            int mulHook(int a, int b) { return _multiplyHook.OriginalFunction(a, b) * 2; }
+            int divHook(int a, int b) { return _divideHook.OriginalFunction(a, b) * 2; }
+            
+            // HookedObjectVirtualFunctionTable only supports hooking objects
+            // where the vtable pointer is at [objectbaseadress]
+            // to test this, we create a pointer to our vtable.
+            // this serves as a fake object, which we can hook
+            IntPtr vTableOriginal = _nativeCalculator.VTable;
+            IntPtr fakeObject = new IntPtr(&vTableOriginal);
+            // We hook the vtable pointer(fakeObject), this changes the vtable pointer but does not hook any functions yet
+            // Checking if this corrupts anything is done in TestVTableCallsAfterHookingVTablePointer
+            var vTableHook = HookedObjectVirtualFunctionTable.HookObject(fakeObject, Enum.GetNames(typeof(NativeCalculator.VTableFunctions)).Length);;
+           
+            _addHook = vTableHook.CreateFunctionHook<NativeCalculator.AddFunction>((int)NativeCalculator.VTableFunctions.Add, addHook).Activate();
+            _subHook = vTableHook.CreateFunctionHook<NativeCalculator.SubtractFunction>((int)NativeCalculator.VTableFunctions.Subtract, subHook).Activate();
+            _multiplyHook = vTableHook.CreateFunctionHook<NativeCalculator.MultiplyFunction>((int)NativeCalculator.VTableFunctions.Multiply, mulHook).Activate();
+            _divideHook = vTableHook.CreateFunctionHook<NativeCalculator.DivideFunction>((int)NativeCalculator.VTableFunctions.Divide, divHook).Activate();
+
+            // We create a VirtualFunctionTable from our fakeObject
+            // Calling the functions should call our hooks
+
+            var vTable = VirtualFunctionTable.FromObject(fakeObject, Enum.GetNames(typeof(NativeCalculator.VTableFunctions)).Length);
+            var addFunction = vTable.CreateWrapperFunction<NativeCalculator.AddFunction>((int)NativeCalculator.VTableFunctions.Add);
+            var subtractFunction = vTable.CreateWrapperFunction<NativeCalculator.SubtractFunction>((int)NativeCalculator.VTableFunctions.Subtract);
+            var multiplyFunction = vTable.CreateWrapperFunction<NativeCalculator.MultiplyFunction>((int)NativeCalculator.VTableFunctions.Multiply);
+            var divideFunction = vTable.CreateWrapperFunction<NativeCalculator.DivideFunction>((int)NativeCalculator.VTableFunctions.Divide);
+            // Test Calling after we hook the vtable function pointers using an 'external' class (VirtualFunctionTable)
+            // This should not modify any results
+            for (int x = 1; x < 100; x++)
+            {
+                for (int y = 100; y > 0; y--)
+                {
+                    int add = (x + y) + 1;
+                    int subtract = (x - y) - 1;
+                    int multiply = (x * y) * 2;
+                    int divide = (x / y) * 2;
+
+                    Assert.Equal(add, addFunction(x, y));
+                    Assert.Equal(subtract, subtractFunction(x, y));
+                    Assert.Equal(multiply, multiplyFunction(x, y));
+                    Assert.Equal(divide, divideFunction(x, y));
+                }
+            }
+        }
+
+        [Fact]
+        public unsafe void TestExternalVTableCallAfterFunctionHookButWithDirectCall()
+        {
+            int addHook(int a, int b) { return _addHook.OriginalFunction(a, b) + 1; }
+            int subHook(int a, int b) { return _subHook.OriginalFunction(a, b) - 1; }
+            int mulHook(int a, int b) { return _multiplyHook.OriginalFunction(a, b) * 2; }
+            int divHook(int a, int b) { return _divideHook.OriginalFunction(a, b) * 2; }
+
+            // HookedObjectVirtualFunctionTable only supports hooking objects
+            // where the vtable pointer is at [objectbaseadress]
+            // to test this, we create a pointer to our vtable.
+            // this serves as a fake object, which we can hook
+            IntPtr vTableOriginal = _nativeCalculator.VTable;
+            IntPtr fakeObject = new IntPtr(&vTableOriginal);
+
+            
+
+            // We hook the vtable pointer(fakeObject), this changes the vtable pointer but does not hook any functions yet
+            // Checking if this corrupts anything is done in TestVTableCallsAfterHookingVTablePointer
+            var vTableHook = HookedObjectVirtualFunctionTable.HookObject(fakeObject, Enum.GetNames(typeof(NativeCalculator.VTableFunctions)).Length); ;
+
+            _addHook = vTableHook.CreateFunctionHook<NativeCalculator.AddFunction>((int)NativeCalculator.VTableFunctions.Add, addHook).Activate();
+            _subHook = vTableHook.CreateFunctionHook<NativeCalculator.SubtractFunction>((int)NativeCalculator.VTableFunctions.Subtract, subHook).Activate();
+            _multiplyHook = vTableHook.CreateFunctionHook<NativeCalculator.MultiplyFunction>((int)NativeCalculator.VTableFunctions.Multiply, mulHook).Activate();
+            _divideHook = vTableHook.CreateFunctionHook<NativeCalculator.DivideFunction>((int)NativeCalculator.VTableFunctions.Divide, divHook).Activate();
+
+            // In this test we access our vtable directly
+            // As the vtable itself is never changed, this should not hook any functions
+            var vTable = VirtualFunctionTable.FromAddress(_nativeCalculator.VTable, Enum.GetNames(typeof(NativeCalculator.VTableFunctions)).Length);
+
+
+            var addFunction = vTable.CreateWrapperFunction<NativeCalculator.AddFunction>((int)NativeCalculator.VTableFunctions.Add);
+            var subtractFunction = vTable.CreateWrapperFunction<NativeCalculator.SubtractFunction>((int)NativeCalculator.VTableFunctions.Subtract);
+            var multiplyFunction = vTable.CreateWrapperFunction<NativeCalculator.MultiplyFunction>((int)NativeCalculator.VTableFunctions.Multiply);
+            var divideFunction = vTable.CreateWrapperFunction<NativeCalculator.DivideFunction>((int)NativeCalculator.VTableFunctions.Divide);
+            // Test Calling after we hook the vtable function pointers using an 'external' class (VirtualFunctionTable)
+            // This should not modify any results
+            for (int x = 1; x < 100; x++)
+            {
+                for (int y = 100; y > 0; y--)
+                {
+                    int add = x + y;
+                    int subtract = x - y;
+                    int multiply = x * y;
+                    int divide = x / y;
+
+                    Assert.Equal(add, addFunction(x, y));
+                    Assert.Equal(subtract, subtractFunction(x, y));
+                    Assert.Equal(multiply, multiplyFunction(x, y));
+                    Assert.Equal(divide, divideFunction(x, y));
+                }
+            }
+        }
+
+    }
+}

--- a/source/Reloaded.Hooks.Tests.X64/Reloaded.Hooks.Tests.X64.csproj
+++ b/source/Reloaded.Hooks.Tests.X64/Reloaded.Hooks.Tests.X64.csproj
@@ -90,4 +90,8 @@
     <NativeLibs Remove="FastcallCalculatorFunctionPointerTest.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <NativeLibs Remove="HookedObjectVtableTest.cs" />
+  </ItemGroup>
+
 </Project>

--- a/source/Reloaded.Hooks.Tests.X86/Reloaded.Hooks.Tests.X86.csproj
+++ b/source/Reloaded.Hooks.Tests.X86/Reloaded.Hooks.Tests.X86.csproj
@@ -42,6 +42,7 @@
     <Compile Include="..\Reloaded.Hooks.Tests.X64\FastcallCalculatorHookTest.cs" Link="FastcallCalculatorHookTest.cs" />
     <Compile Include="..\Reloaded.Hooks.Tests.X64\FastcallCalculatorTest.cs" Link="FastcallCalculatorTest.cs" />
     <Compile Include="..\Reloaded.Hooks.Tests.X64\FunctionPatcherTest.cs" Link="FunctionPatcherTest.cs" />
+    <Compile Include="..\Reloaded.Hooks.Tests.X64\HookedObjectVtableTest.cs" Link="HookedObjectVtableTest.cs" />
     <Compile Include="..\Reloaded.Hooks.Tests.X64\ReloadedHooksTest.cs" Link="ReloadedHooksTest.cs" />
     <Compile Include="..\Reloaded.Hooks.Tests.X64\SuperStackedHooks.cs" Link="SuperStackedHooks.cs" />
     <Compile Include="..\Reloaded.Hooks.Tests.X64\VTableTest.cs" Link="VTableTest.cs" />

--- a/source/Reloaded.Hooks/ReloadedHooks.cs
+++ b/source/Reloaded.Hooks/ReloadedHooks.cs
@@ -68,9 +68,32 @@ namespace Reloaded.Hooks
 
             return new X64.ReverseWrapper<TFunction>(function);
         }
-
+        /// <summary>
+        /// Hooks an object's virtual function table from an object address in memory.
+        /// Only this object is hooked, other objects are unaffected.
+        /// An assumption is made that the virtual function table pointer is the first parameter of the object.
+        /// This ethod hooks the virtual function table pointer by copying the object's virtual function table
+        /// and changing the objects virtual function table pointer to the address of the copy.
+        /// After calling this, individual functions must be hooked by calling CreateFunctionHook.
+        /// </summary>
+        /// <param name="objectAddress">
+        ///     The memory address at which the object is stored.
+        ///     The function will assume that the first entry is a pointer to the virtual function
+        ///     table, as standard with C++ code.
+        /// </param>
+        /// <param name="numberOfMethods">
+        ///     The number of methods contained in the virtual function table.
+        ///     For enumerables, you may obtain this value as such: Enum.GetNames(typeof(MyEnum)).Length; where
+        ///     MyEnum is the name of your enumerable.
+        ///     Make sure this number is at least as big as your target vtable, 
+        ///     as we need to copy -all- of the vtable function pointers.
+        /// </param>
+        /// <returns></returns>
+        public IVirtualFunctionTable HookObjectVirtualFunctionTablePointer(IntPtr objectAddress, int numberOfMethods) => HookedObjectVirtualFunctionTable.HookObject(objectAddress, numberOfMethods);
+        
         public IVirtualFunctionTable VirtualFunctionTableFromObject(IntPtr objectAddress, int numberOfMethods) => VirtualFunctionTable.FromObject(objectAddress, numberOfMethods);
         public IVirtualFunctionTable VirtualFunctionTableFromAddress(IntPtr tableAddress, int numberOfMethods) => VirtualFunctionTable.FromAddress(tableAddress, numberOfMethods);
+
         public IFunctionPtr<TDelegate> CreateFunctionPtr<TDelegate>(ulong functionPointer) where TDelegate : Delegate => new FunctionPtr<TDelegate>(functionPointer);
         public IAsmHook CreateAsmHook(string[] asmCode, long functionAddress) => CreateAsmHook(asmCode, functionAddress, AsmHookBehaviour.ExecuteFirst, -1);
 

--- a/source/Reloaded.Hooks/Tools/HookedObjectVirtualFunctionTable.cs
+++ b/source/Reloaded.Hooks/Tools/HookedObjectVirtualFunctionTable.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Reloaded.Hooks.Definitions;
+using static Reloaded.Memory.Sources.Memory;
+using Reloaded.Memory.Sources;
+namespace Reloaded.Hooks.Tools
+{
+    /// <summary>
+    /// Hooks an object's virtual function table from an object address in memory.
+    /// Only this object is hooked, other objects are unaffected.
+    /// An assumption is made that the virtual function table pointer is the first parameter.
+    /// This hooks the virtual function table pointer by copying the object's virtual function table
+    /// and changing the objects virtual function table pointer to the address of the copy.
+    /// After calling this, individual functions must be hooked by calling CreateFunctionHook.
+    /// </summary>
+    public class HookedObjectVirtualFunctionTable : IVirtualFunctionTable
+    {
+        internal class VTableEntryHook<TFunction> : IHook<TFunction>
+        {
+            private readonly HookedObjectVirtualFunctionTable _vTableHook;
+            private readonly int _index;
+            private readonly bool _is64Bit;
+
+            /// <summary>
+            /// Hooks an individual vtable function pointer from a already hooked vtable pointer.
+            /// </summary>
+            /// <param name="vTableHook">The already hooked virtual function table</param>
+            /// <param name="originalVirtualFunctionTableAddress">The address of the original virtual function pointer
+            /// This will be read to store the original function pointer</param>
+            /// <param name="index">The index of the virtual function pointer in the virtual function table</param>
+            /// <param name="function">The hook function</param>
+            internal unsafe VTableEntryHook(HookedObjectVirtualFunctionTable vTableHook, IntPtr originalVirtualFunctionTableAddress, int index,
+                TFunction function)
+            {
+                CurrentProcess.SafeRead(originalVirtualFunctionTableAddress + index * sizeof(IntPtr),
+                    out IntPtr originalFunctionAddress);
+
+                _vTableHook = vTableHook;
+                _index = index;
+                _is64Bit = sizeof(IntPtr) == 8;
+                ReverseWrapper = CreateReverseWrapper(function);
+                OriginalFunction = CreateWrapper(originalFunctionAddress.ToInt64(),
+                    out IntPtr originalFunctionWrapperAddress);
+                OriginalFunctionAddress = originalFunctionAddress;
+                OriginalFunctionWrapperAddress = originalFunctionWrapperAddress;
+                IsHookActivated = false;
+            }
+            /// <inheritdoc />
+            public TFunction OriginalFunction { get; }
+            /// <inheritdoc />
+            public IReverseWrapper<TFunction> ReverseWrapper { get; }
+            /// <inheritdoc />
+            public bool IsHookEnabled { get; private set; }
+            /// <inheritdoc />
+            public bool IsHookActivated { get; private set; }
+            /// <inheritdoc />
+            public IntPtr OriginalFunctionAddress { get; }
+            /// <inheritdoc />
+            public IntPtr OriginalFunctionWrapperAddress { get; }
+            /// <inheritdoc />
+            protected IReverseWrapper<TFunction> CreateReverseWrapper(TFunction function)
+            {
+                if (_is64Bit)
+                    return new X64.ReverseWrapper<TFunction>(function);
+
+                return new X86.ReverseWrapper<TFunction>(function);
+            }
+            /// <inheritdoc />
+            protected TFunction CreateWrapper(long functionAddress, out IntPtr wrapperAddress)
+            {
+                if (_is64Bit)
+                    return X64.Wrapper.Create<TFunction>(functionAddress, out wrapperAddress);
+
+                return X86.Wrapper.Create<TFunction>(functionAddress, out wrapperAddress);
+            }
+            /// <inheritdoc />
+            IHook IHook.Activate() => Activate();
+            /// <inheritdoc />
+            public IHook<TFunction> Activate()
+            {
+                _vTableHook.AddHook(this);
+                Enable();
+                IsHookActivated = true;
+                return this;
+            }
+            /// <inheritdoc />
+            public void Disable()
+            {
+                _vTableHook.SetHookedVTableEntry(_index, OriginalFunctionAddress);
+                IsHookEnabled = false;
+            }
+            /// <inheritdoc />
+            public void Enable()
+            {
+                _vTableHook.SetHookedVTableEntry(_index, ReverseWrapper.WrapperPointer);
+                IsHookEnabled = true;
+            }
+        }
+
+        private readonly IntPtr _originalVirtualFunctionTableAddress;
+        private readonly IntPtr[] _newVTableForObject;
+        private readonly GCHandle _pinnedNewVTableForObject;
+        private readonly List<IHook> _hooks;
+        /// <inheritdoc />
+        public List<TableEntry> TableEntries { get; set; }
+        /// <summary>
+        /// The address of the hooked object
+        /// </summary>
+        public IntPtr ObjectAddress { get; private set; }
+
+        /// <inheritdoc />
+        public TableEntry this[int i]
+        {
+            get => TableEntries[i];
+            set => TableEntries[i] = value;
+        }
+
+        /// <summary>
+        /// Adds the individual vtable hook to a list so it can not be garbage collected, while the main object is still active
+        /// </summary>
+        /// <param name="hook">The hook to add</param>
+        private void AddHook(IHook hook)
+        {
+            _hooks.Add(hook);
+        }
+        /// <summary>
+        /// Hooks an object's virtual function table from an object address in memory.
+        /// Only this object is hooked, other objects are unaffected.
+        /// An assumption is made that the virtual function table pointer is the first parameter.
+        /// This hooks the virtual function table pointer by copying the object's virtual function table
+        /// and changing the objects virtual function table pointer to the address of the copy.
+        /// After calling this, individual functions must be hooked by calling CreateFunctionHook.
+        /// </summary>
+        /// <param name="objectAddress">
+        ///     The memory address at which the object is stored.
+        ///     The function will assume that the first entry is a pointer to the virtual function
+        ///     table, as standard with C++ code.
+        /// </param>
+        /// <param name="numberOfMethods">
+        ///     The number of methods contained in the virtual function table.
+        ///     For enumerables, you may obtain this value as such: Enum.GetNames(typeof(MyEnum)).Length; where
+        ///     MyEnum is the name of your enumerable.
+        ///     Make sure this number is at least as big as your target vtable, 
+        ///     as we need to copy -all- of the vtable function pointers.
+        /// </param>
+        public static HookedObjectVirtualFunctionTable HookObject(IntPtr objectAddress, int numberOfMethods)
+        {
+            CurrentProcess.SafeRead(objectAddress, out IntPtr virtualFunctionTableAddress);
+            var table = GetAddresses(virtualFunctionTableAddress, numberOfMethods);
+            return new HookedObjectVirtualFunctionTable(objectAddress, virtualFunctionTableAddress, table);
+        }
+        /// <inheritdoc />
+        public IHook<TFunction> CreateFunctionHook<TFunction>(int index, TFunction delegateType)
+        {
+            return new VTableEntryHook<TFunction>(this, _originalVirtualFunctionTableAddress, index, delegateType);
+        }
+        /// <inheritdoc />
+        public unsafe TFunction CreateWrapperFunction<TFunction>(int index)
+        {
+            if (sizeof(IntPtr) == 4)
+                return X86.Wrapper.Create<TFunction>((long)TableEntries[index].FunctionPointer, out var wrapperAddress);
+            if (sizeof(IntPtr) == 8)
+                return X64.Wrapper.Create<TFunction>((long)TableEntries[index].FunctionPointer, out var wrapperAddress);
+
+            throw new Exception("Machine does not appear to be of a 32 or 64bit architecture.");
+        }
+        private HookedObjectVirtualFunctionTable(IntPtr objectAddress, IntPtr virtualFunctionTableAddress, List<TableEntry> table)
+        {
+            ObjectAddress = objectAddress;
+            TableEntries = table;
+            
+            _originalVirtualFunctionTableAddress = virtualFunctionTableAddress;
+            _newVTableForObject = new IntPtr[table.Count];
+            _hooks = new List<IHook>();
+            for (int i = 0; i < table.Count; i++)
+            {
+                _newVTableForObject[i] = table[i].FunctionPointer;
+            }
+
+            _pinnedNewVTableForObject = GCHandle.Alloc(_newVTableForObject, GCHandleType.Pinned);
+            CurrentProcess.SafeWrite(objectAddress, _pinnedNewVTableForObject.AddrOfPinnedObject());
+        }
+        private void SetHookedVTableEntry(int index, IntPtr newEntry)
+        {
+            _newVTableForObject[index] = newEntry;
+        }
+        /*
+            ---------------
+            Factory Methods
+            ---------------
+        */
+        private static List<TableEntry> GetAddresses(IntPtr tablePointer, int numberOfMethods)
+        {
+            // Stores the addresses of the virtual function table.
+            List<TableEntry> tablePointers = new List<TableEntry>();
+
+            // Append the table pointers onto the tablePointers list.
+            // Using the size of the IntPtr allows for both x64 and x86 support.
+            for (int i = 0; i < numberOfMethods; i++)
+            {
+                IntPtr targetAddress = tablePointer + (IntPtr.Size * i);
+
+                CurrentProcess.SafeRead(targetAddress, out IntPtr functionPtr);
+                tablePointers.Add(new TableEntry
+                {
+                    EntryAddress = targetAddress,
+                    FunctionPointer = functionPtr
+                });
+            }
+
+            return tablePointers;
+        }
+    }
+}


### PR DESCRIPTION
Hooking virtual functions is currently done in Reloaded.Hooks by making changes to the function itself in memory.
This hooks the original function and therefore everytime the virtual function of an object is called,
the hook will be called instead.

Hooking this way lead to problems for me(it appears mixing Reloaded.Hooks with already hooked SteamVR hooks is not currently supported/working)

I've added HookedObjectVirtualFunctionTable and (as a utility) ReloadedHooks.HookObjectVirtualFunctionTablePointer. 
This class hooks the virtual function table pointer of an object by copying its virtual function table
and changing its vtable pointer to the copy.
Therefore only this object's vtable is hooked, other objects are unaffected.
To hook a function, the entry in the vtable copy is then changed.
By hooking the vtable this way, it's clear our hooks are compatible with other already existing hooks.

I've implemented these new classes by following the already existing interfaces IVirtualFunctionTable and IHook<TFunction>

The naming of the new classes (HookedObjectVirtualFunctionTable and VTableEntryHook) should hopefully 
make the difference to the old VirtualFunctionTable clear enough, but feel free to change them.


I've also added tests which test calling the original functions of the vtable with the new class, 
hooking the vtable pointer and calling the unhooked virtual functions and hooking the vtable pointer and 
the functions and calling the functions.